### PR TITLE
[Fixed] Delete mousemap

### DIFF
--- a/Default.sublime-mousemap
+++ b/Default.sublime-mousemap
@@ -1,4 +1,0 @@
-[{
-  "button": "button3","count": "1",
-  "press_command": "middle_click"
-}]


### PR DESCRIPTION
### 1. Behavior before pull request

I don't can use middle mouse button. For example, I need middle mouse button, if I select columns.

![Column](http://i.imgur.com/F9WDvM8.png)

If I click middle mouse button, I see in console:

```json
command: middle_click {"event": {"button": 3, "x": 520.5, "y": 399.5}}
hey middle click listener worked
19
None
```

### 2. Behavior after pull request

I work with `middle_click` without problems.

Thanks.